### PR TITLE
fix: update dhis2 urls to new climate-tools-42 dhis2 instance

### DIFF
--- a/docs/_unused/auto-import-dhis2-monthly.ipynb
+++ b/docs/_unused/auto-import-dhis2-monthly.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/docs/guides/import-data/import-data-values.ipynb
+++ b/docs/guides/import-data/import-data-values.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "de00fa95",
    "metadata": {},
    "outputs": [
@@ -69,7 +69,7 @@
    "source": [
     "# Client configuration\n",
     "cfg = ClientSettings(\n",
-    "  base_url=\"https://play.im.dhis2.org/stable-2-42-3-1\",\n",
+    "  base_url=\"https://climate.im.dhis2.org/climate-tools-42\",\n",
     "  username=\"admin\",\n",
     "  password=\"district\")\n",
     "\n",
@@ -376,7 +376,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "climate-tools-new",
+   "display_name": "climate-tools-py313",
    "language": "python",
    "name": "python3"
   },
@@ -390,7 +390,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/guides/import-data/prepare-metadata.ipynb
+++ b/docs/guides/import-data/prepare-metadata.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +45,7 @@
     "\n",
     "# Client configuration\n",
     "cfg = ClientSettings(\n",
-    "  base_url=\"https://play.im.dhis2.org/stable-2-42-3-1\",\n",
+    "  base_url=\"https://climate.im.dhis2.org/climate-tools-42\",\n",
     "  username=\"admin\",\n",
     "  password=\"district\")\n",
     "\n",

--- a/docs/guides/org-units/download-web-api.ipynb
+++ b/docs/guides/org-units/download-web-api.ipynb
@@ -63,7 +63,7 @@
    "source": [
     "# Client configuration\n",
     "cfg = ClientSettings(\n",
-    "  base_url=\"https://play.im.dhis2.org/stable-2-42-3-1\",\n",
+    "  base_url=\"https://climate.im.dhis2.org/climate-tools-42\",\n",
     "  username=\"admin\",\n",
     "  password=\"district\")\n",
     "\n",

--- a/docs/workflows/import-chirps3/import-chirps3-daily.ipynb
+++ b/docs/workflows/import-chirps3/import-chirps3-daily.ipynb
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "# DHIS2 connection\n",
-    "DHIS2_BASE_URL = \"https://play.im.dhis2.org/stable-2-42-3-1\"\n",
+    "DHIS2_BASE_URL = \"https://climate.im.dhis2.org/climate-tools-42\"\n",
     "DHIS2_USERNAME = \"admin\"\n",
     "DHIS2_PASSWORD = \"district\"\n",
     "\n",

--- a/docs/workflows/import-era5/import-era5-daily.ipynb
+++ b/docs/workflows/import-era5/import-era5-daily.ipynb
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "parameters"
@@ -111,7 +111,7 @@
    "outputs": [],
    "source": [
     "# DHIS2 connection\n",
-    "DHIS2_BASE_URL = \"https://play.im.dhis2.org/stable-2-42-3-1\"\n",
+    "DHIS2_BASE_URL = \"https://climate.im.dhis2.org/climate-tools-42\"\n",
     "DHIS2_USERNAME = \"admin\"\n",
     "DHIS2_PASSWORD = \"district\"\n",
     "\n",

--- a/docs/workflows/import-worldpop/import-pop-yearly.ipynb
+++ b/docs/workflows/import-worldpop/import-pop-yearly.ipynb
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "# DHIS2 connection\n",
-    "DHIS2_BASE_URL = \"https://play.im.dhis2.org/stable-2-42-3-1\"\n",
+    "DHIS2_BASE_URL = \"https://climate.im.dhis2.org/climate-tools-42\"\n",
     "DHIS2_USERNAME = \"admin\"\n",
     "DHIS2_PASSWORD = \"district\"\n",
     "\n",

--- a/docs/workflows/scheduling/example/configs/import-temperature-config.yaml
+++ b/docs/workflows/scheduling/example/configs/import-temperature-config.yaml
@@ -1,4 +1,4 @@
-DHIS2_BASE_URL: https://play.im.dhis2.org/stable-2-42-3-1
+DHIS2_BASE_URL: https://climate.im.dhis2.org/climate-tools-42
 DHIS2_USERNAME: admin
 DHIS2_PASSWORD: district
 

--- a/docs/workflows/scheduling/example/notebooks/import-era5-daily.ipynb
+++ b/docs/workflows/scheduling/example/notebooks/import-era5-daily.ipynb
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "parameters"
@@ -111,31 +111,31 @@
    "outputs": [],
    "source": [
     "# DHIS2 connection\n",
-    "DHIS2_BASE_URL = \"https://play.im.dhis2.org/stable-2-42-3-1\"\n",
+    "DHIS2_BASE_URL = \"https://climate.im.dhis2.org/climate-tools-42\"\n",
     "DHIS2_USERNAME = \"admin\"\n",
     "DHIS2_PASSWORD = \"district\"\n",
     "\n",
     "# DHIS2 import settings\n",
-    "DHIS2_DATA_ELEMENT_ID = '<INSERT-DATA-ELEMENT-ID>'\n",
+    "DHIS2_DATA_ELEMENT_ID = 'nRAhtHkpQF0'\n",
     "DHIS2_ORG_UNIT_LEVEL = 2\n",
     "DHIS2_DRY_RUN = True                            # default to safe dry-run mode; set to False for actual import\n",
     "DHIS2_TIMEZONE_OFFSET = 0                       # set to UTC timezone offset for your country\n",
     "\n",
     "# ERA5 import configuration\n",
-    "IMPORT_VARIABLE = \"total_precipitation\"         # ERA5 variable to download (as named in the CDS catalogue)\n",
-    "IMPORT_VALUE_COL = \"tp\"                         # variable name in the downloaded xarray dataset\n",
-    "IMPORT_IS_CUMULATIVE = True                     # indicates whether the input data is cumulative over time (e.g. ERA5 precipitation)\n",
-    "IMPORT_FROM_UNITS = \"m\"                         # units of the original data values\n",
-    "IMPORT_TO_UNITS = \"mm\"                          # convert to these units before import\n",
+    "IMPORT_VARIABLE = \"2m_temperature\"         # ERA5 variable to download (as named in the CDS catalogue)\n",
+    "IMPORT_VALUE_COL = \"t2m\"                         # variable name in the downloaded xarray dataset\n",
+    "IMPORT_IS_CUMULATIVE = False                     # indicates whether the input data is cumulative over time (e.g. ERA5 precipitation)\n",
+    "IMPORT_FROM_UNITS = \"kelvin\"                         # units of the original data values\n",
+    "IMPORT_TO_UNITS = \"degC\"                          # convert to these units before import\n",
     "IMPORT_START_DATE = \"2025-01-01\"                # how far back in time to start import\n",
     "IMPORT_END_DATE = date.today().isoformat()      # automatically tries to import the latest data\n",
     "\n",
     "# Download settings\n",
     "DOWNLOAD_FOLDER = \"../../guides/data/local\"\n",
-    "DOWNLOAD_PREFIX = \"era5-hourly-precip\"          # prefix for caching downloads; existing files are reused\n",
+    "DOWNLOAD_PREFIX = \"era5-hourly-temp\"          # prefix for caching downloads; existing files are reused\n",
     "\n",
     "# Aggregation settings\n",
-    "TEMPORAL_AGGREGATION = \"sum\"\n",
+    "TEMPORAL_AGGREGATION = \"mean\"\n",
     "SPATIAL_AGGREGATION = \"mean\""
    ]
   },
@@ -157,7 +157,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current DHIS2 version: 2.42.3.1\n"
+      "Current DHIS2 version: 2.42.4\n"
      ]
     }
    ],
@@ -192,13 +192,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Skipping field groups: unsupported OGR type: 5\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -225,6 +218,7 @@
        "      <th>level</th>\n",
        "      <th>parent</th>\n",
        "      <th>parentGraph</th>\n",
+       "      <th>groups</th>\n",
        "      <th>geometry</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -237,6 +231,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[w1Atoz18PCL, jqBqIXoXpfy]</td>\n",
        "      <td>POLYGON ((-11.5914 8.4875, -11.5906 8.4769, -1...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -247,6 +242,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[w1Atoz18PCL, J40PpdN4Wkk, GGghZsfu7qV]</td>\n",
        "      <td>POLYGON ((-11.8091 9.2032, -11.8102 9.1944, -1...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -257,6 +253,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[w1Atoz18PCL, jqBqIXoXpfy, GGghZsfu7qV]</td>\n",
        "      <td>MULTIPOLYGON (((-12.5568 7.3832, -12.5574 7.38...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -267,6 +264,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[w1Atoz18PCL, GGghZsfu7qV, nlX2VoouN63]</td>\n",
        "      <td>POLYGON ((-10.7972 7.5866, -10.8002 7.5878, -1...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -277,6 +275,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[w1Atoz18PCL, GGghZsfu7qV, b0EsAxm8Nge, nlX2Vo...</td>\n",
        "      <td>MULTIPOLYGON (((-13.1349 8.8471, -13.1343 8.84...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -287,6 +286,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL]</td>\n",
        "      <td>POLYGON ((-11.3596 8.5317, -11.3513 8.5234, -1...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -297,6 +297,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]</td>\n",
        "      <td>POLYGON ((-10.585 9.0434, -10.5877 9.0432, -10...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -307,6 +308,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]</td>\n",
        "      <td>POLYGON ((-10.585 9.0434, -10.5848 9.0432, -10...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -317,6 +319,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, jqBqIXoXpfy]</td>\n",
        "      <td>MULTIPOLYGON (((-12.6351 7.6613, -12.6346 7.66...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -327,6 +330,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, b0EsAxm8Nge]</td>\n",
        "      <td>MULTIPOLYGON (((-13.119 8.4718, -13.1174 8.470...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -337,6 +341,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, nlX2VoouN63]</td>\n",
        "      <td>MULTIPOLYGON (((-11.5346 6.944, -11.5338 6.943...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -347,6 +352,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]</td>\n",
        "      <td>POLYGON ((-11.3546 8.6455, -11.357 8.6345, -11...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -357,6 +363,7 @@
        "      <td>2</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
        "      <td>ImspTQPwCqd</td>\n",
+       "      <td>[f25dqv3Y7Z0, w1Atoz18PCL, b0EsAxm8Nge]</td>\n",
        "      <td>MULTIPOLYGON (((-13.2435 8.1007, -13.2429 8.10...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -378,6 +385,21 @@
        "10  bL4ooGhyHRQ  OU_260377       Pujehun     2  ImspTQPwCqd  ImspTQPwCqd   \n",
        "11  eIQbndfxQMb  OU_268149     Tonkolili     2  ImspTQPwCqd  ImspTQPwCqd   \n",
        "12  at6UHUQatSo  OU_278310  Western Area     2  ImspTQPwCqd  ImspTQPwCqd   \n",
+       "\n",
+       "                                               groups  \\\n",
+       "0                          [w1Atoz18PCL, jqBqIXoXpfy]   \n",
+       "1             [w1Atoz18PCL, J40PpdN4Wkk, GGghZsfu7qV]   \n",
+       "2             [w1Atoz18PCL, jqBqIXoXpfy, GGghZsfu7qV]   \n",
+       "3             [w1Atoz18PCL, GGghZsfu7qV, nlX2VoouN63]   \n",
+       "4   [w1Atoz18PCL, GGghZsfu7qV, b0EsAxm8Nge, nlX2Vo...   \n",
+       "5                          [f25dqv3Y7Z0, w1Atoz18PCL]   \n",
+       "6             [f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]   \n",
+       "7             [f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]   \n",
+       "8             [f25dqv3Y7Z0, w1Atoz18PCL, jqBqIXoXpfy]   \n",
+       "9             [f25dqv3Y7Z0, w1Atoz18PCL, b0EsAxm8Nge]   \n",
+       "10            [f25dqv3Y7Z0, w1Atoz18PCL, nlX2VoouN63]   \n",
+       "11            [f25dqv3Y7Z0, w1Atoz18PCL, J40PpdN4Wkk]   \n",
+       "12            [f25dqv3Y7Z0, w1Atoz18PCL, b0EsAxm8Nge]   \n",
        "\n",
        "                                             geometry  \n",
        "0   POLYGON ((-11.5914 8.4875, -11.5906 8.4769, -1...  \n",
@@ -420,13 +442,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'meta': {'dataElement': 'PGDgmnWmXT6',\n",
+       "{'meta': {'dataElement': 'nRAhtHkpQF0',\n",
        "  'level': 2,\n",
        "  'periodType': 'DAILY',\n",
        "  'calendar': 'iso8601',\n",
@@ -435,7 +457,7 @@
        " 'next': None}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -521,62 +543,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading data for the period: 2025-01-01 to 2026-01-21...\n",
-      "INFO - 2026-01-21 22:52:17,068 - dhis2eo.data.cds.era5_land.hourly - Month 2025-1\n",
-      "INFO - 2026-01-21 22:52:17,071 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-01.nc\n",
-      "INFO - 2026-01-21 22:52:17,073 - dhis2eo.data.cds.era5_land.hourly - Month 2025-2\n",
-      "INFO - 2026-01-21 22:52:17,076 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-02.nc\n",
-      "INFO - 2026-01-21 22:52:17,078 - dhis2eo.data.cds.era5_land.hourly - Month 2025-3\n",
-      "INFO - 2026-01-21 22:52:17,080 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-03.nc\n",
-      "INFO - 2026-01-21 22:52:17,082 - dhis2eo.data.cds.era5_land.hourly - Month 2025-4\n",
-      "INFO - 2026-01-21 22:52:17,083 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-04.nc\n",
-      "INFO - 2026-01-21 22:52:17,085 - dhis2eo.data.cds.era5_land.hourly - Month 2025-5\n",
-      "INFO - 2026-01-21 22:52:17,088 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-05.nc\n",
-      "INFO - 2026-01-21 22:52:17,091 - dhis2eo.data.cds.era5_land.hourly - Month 2025-6\n",
-      "INFO - 2026-01-21 22:52:17,094 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-06.nc\n",
-      "INFO - 2026-01-21 22:52:17,095 - dhis2eo.data.cds.era5_land.hourly - Month 2025-7\n",
-      "INFO - 2026-01-21 22:52:17,099 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-07.nc\n",
-      "INFO - 2026-01-21 22:52:17,101 - dhis2eo.data.cds.era5_land.hourly - Month 2025-8\n",
-      "INFO - 2026-01-21 22:52:17,103 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-08.nc\n",
-      "INFO - 2026-01-21 22:52:17,105 - dhis2eo.data.cds.era5_land.hourly - Month 2025-9\n",
-      "INFO - 2026-01-21 22:52:17,109 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-09.nc\n",
-      "INFO - 2026-01-21 22:52:17,111 - dhis2eo.data.cds.era5_land.hourly - Month 2025-10\n",
-      "INFO - 2026-01-21 22:52:17,115 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-10.nc\n",
-      "INFO - 2026-01-21 22:52:17,117 - dhis2eo.data.cds.era5_land.hourly - Month 2025-11\n",
-      "INFO - 2026-01-21 22:52:17,120 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-11.nc\n",
-      "INFO - 2026-01-21 22:52:17,121 - dhis2eo.data.cds.era5_land.hourly - Month 2025-12\n",
-      "INFO - 2026-01-21 22:52:17,124 - dhis2eo.data.cds.era5_land.hourly - File already downloaded: C:\\Users\\karimba\\Documents\\Github\\climate-tools\\docs\\guides\\data\\local\\era5-hourly-precip_2025-12.nc\n",
-      "INFO - 2026-01-21 22:52:17,125 - dhis2eo.data.cds.era5_land.hourly - Month 2026-1\n",
-      "WARNING - 2026-01-21 22:52:17,127 - dhis2eo.data.cds.era5_land.hourly - Skipping downloads for months that are expected to be incomplete (~7 days of lag).Latest available date expected in ERA5-Land: 2026-01-14\n"
+      "Downloading data for the period: 2025-01-01 to 2026-02-17...\n",
+      "INFO - 2026-02-17 22:17:59,372 - dhis2eo.data.cds.era5_land.hourly - Month 2025-1\n",
+      "INFO - 2026-02-17 22:17:59,375 - dhis2eo.data.cds.era5_land.hourly - Downloading data from CDS API...\n",
+      "INFO - 2026-02-17 22:17:59,376 - dhis2eo.data.cds.era5_land.hourly - Request parameters: \n",
+      "{\"variable\": [\"2m_temperature\"], \"year\": \"2025\", \"month\": [\"01\"], \"day\": [\"01\", \"02\", \"03\", \"04\", \"05\", \"06\", \"07\", \"08\", \"09\", \"10\", \"11\", \"12\", \"13\", \"14\", \"15\", \"16\", \"17\", \"18\", \"19\", \"20\", \"21\", \"22\", \"23\", \"24\", \"25\", \"26\", \"27\", \"28\", \"29\", \"30\", \"31\"], \"time\": [\"00:00\", \"01:00\", \"02:00\", \"03:00\", \"04:00\", \"05:00\", \"06:00\", \"07:00\", \"08:00\", \"09:00\", \"10:00\", \"11:00\", \"12:00\", \"13:00\", \"14:00\", \"15:00\", \"16:00\", \"17:00\", \"18:00\", \"19:00\", \"20:00\", \"21:00\", \"22:00\", \"23:00\"], \"area\": [10.0004, -13.3035, 6.9176, -10.2658], \"data_format\": \"netcdf\", \"download_format\": \"unarchived\"}\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "[WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-01.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-02.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-03.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-04.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-05.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-06.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-07.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-08.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-09.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-10.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-11.nc'),\n",
-       " WindowsPath('C:/Users/karimba/Documents/Github/climate-tools/docs/guides/data/local/era5-hourly-precip_2025-12.nc')]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-17 22:18:01,675 INFO [2025-12-11T00:00:00] Please note that a dedicated catalogue entry for this dataset, post-processed and stored in Analysis Ready Cloud Optimized (ARCO) format (Zarr), is available for optimised time-series retrievals (i.e. for retrieving data from selected variables for a single point over an extended period of time in an efficient way). You can discover it [here](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-timeseries?tab=overview)\n",
+      "2026-02-17 22:18:01,679 INFO Request ID is 5c8250e2-1173-4e63-a1c1-c8bf78018a10\n",
+      "2026-02-17 22:18:01,755 INFO status has been updated to accepted\n",
+      "2026-02-17 22:18:15,360 INFO status has been updated to running\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[8]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mDownloading data for the period: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mIMPORT_START_DATE_OVERRIDE\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m to \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mIMPORT_END_DATE\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m...\u001b[39m\u001b[33m'\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m files = \u001b[43mera5_land\u001b[49m\u001b[43m.\u001b[49m\u001b[43mhourly\u001b[49m\u001b[43m.\u001b[49m\u001b[43mdownload\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      3\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstart\u001b[49m\u001b[43m=\u001b[49m\u001b[43mIMPORT_START_DATE_OVERRIDE\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[32m      4\u001b[39m \u001b[43m    \u001b[49m\u001b[43mend\u001b[49m\u001b[43m=\u001b[49m\u001b[43mIMPORT_END_DATE\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[32m      5\u001b[39m \u001b[43m    \u001b[49m\u001b[43mbbox\u001b[49m\u001b[43m=\u001b[49m\u001b[43morg_units\u001b[49m\u001b[43m.\u001b[49m\u001b[43mtotal_bounds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[32m      6\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdirname\u001b[49m\u001b[43m=\u001b[49m\u001b[43mDOWNLOAD_FOLDER\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[32m      7\u001b[39m \u001b[43m    \u001b[49m\u001b[43mprefix\u001b[49m\u001b[43m=\u001b[49m\u001b[43mDOWNLOAD_PREFIX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[32m      8\u001b[39m \u001b[43m    \u001b[49m\u001b[43mvariables\u001b[49m\u001b[43m=\u001b[49m\u001b[43m[\u001b[49m\u001b[43mIMPORT_VARIABLE\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m      9\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     10\u001b[39m files\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\Github\\dhis2eo\\dhis2eo\\data\\cds\\era5_land\\hourly.py:112\u001b[39m, in \u001b[36mdownload\u001b[39m\u001b[34m(start, end, bbox, dirname, prefix, variables, overwrite)\u001b[39m\n\u001b[32m    108\u001b[39m     logger.info(\u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mFile already downloaded: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msave_path\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m'\u001b[39m)\n\u001b[32m    110\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    111\u001b[39m     \u001b[38;5;66;03m# Download the data\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m112\u001b[39m     ds = \u001b[43mfetch_month\u001b[49m\u001b[43m(\u001b[49m\u001b[43myear\u001b[49m\u001b[43m=\u001b[49m\u001b[43myear\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmonth\u001b[49m\u001b[43m=\u001b[49m\u001b[43mmonth\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbbox\u001b[49m\u001b[43m=\u001b[49m\u001b[43mbbox\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvariables\u001b[49m\u001b[43m=\u001b[49m\u001b[43mvariables\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    114\u001b[39m     \u001b[38;5;66;03m# Save to target path\u001b[39;00m\n\u001b[32m    115\u001b[39m     ds.to_netcdf(save_path)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\Github\\dhis2eo\\dhis2eo\\data\\cds\\era5_land\\hourly.py:47\u001b[39m, in \u001b[36mfetch_month\u001b[39m\u001b[34m(year, month, bbox, variables)\u001b[39m\n\u001b[32m     45\u001b[39m logger.info(\u001b[33m\"\u001b[39m\u001b[33mDownloading data from CDS API...\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     46\u001b[39m logger.info(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mRequest parameters: \u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mjson.dumps(params)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m47\u001b[39m data = \u001b[43mearthkit\u001b[49m\u001b[43m.\u001b[49m\u001b[43mdata\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfrom_source\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcds\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mreanalysis-era5-land\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     49\u001b[39m \u001b[38;5;66;03m# load lazily from disk using xarray\u001b[39;00m\n\u001b[32m     50\u001b[39m ds = xr.open_dataset(data.path)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\__init__.py:158\u001b[39m, in \u001b[36mfrom_source\u001b[39m\u001b[34m(name, lazily, *args, **kwargs)\u001b[39m\n\u001b[32m    155\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m from_source_lazily(name, *args, **kwargs)\n\u001b[32m    157\u001b[39m prev = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m158\u001b[39m src = \u001b[43mget_source\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    159\u001b[39m \u001b[38;5;28;01mwhile\u001b[39;00m src \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m prev:\n\u001b[32m    160\u001b[39m     prev = src\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\__init__.py:139\u001b[39m, in \u001b[36mSourceMaker.__call__\u001b[39m\u001b[34m(self, name, *args, **kwargs)\u001b[39m\n\u001b[32m    136\u001b[39m     klass = find_plugin(os.path.dirname(\u001b[34m__file__\u001b[39m), name, loader)\n\u001b[32m    137\u001b[39m     \u001b[38;5;28mself\u001b[39m.SOURCES[name] = klass\n\u001b[32m--> \u001b[39m\u001b[32m139\u001b[39m source = \u001b[43mklass\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    141\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(source, \u001b[33m\"\u001b[39m\u001b[33mname\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    142\u001b[39m     source.name = name\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\core\\__init__.py:22\u001b[39m, in \u001b[36mMetaBase.__call__\u001b[39m\u001b[34m(cls, *args, **kwargs)\u001b[39m\n\u001b[32m     20\u001b[39m obj = \u001b[38;5;28mcls\u001b[39m.\u001b[34m__new__\u001b[39m(\u001b[38;5;28mcls\u001b[39m, *args, **kwargs)\n\u001b[32m     21\u001b[39m args, kwargs = \u001b[38;5;28mcls\u001b[39m.patch(obj, *args, **kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m22\u001b[39m \u001b[43mobj\u001b[49m\u001b[43m.\u001b[49m\u001b[34;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     23\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m obj\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\cds.py:126\u001b[39m, in \u001b[36mCdsRetriever.__init__\u001b[39m\u001b[34m(self, dataset, prompt, *args, **kwargs)\u001b[39m\n\u001b[32m    123\u001b[39m nthreads = \u001b[38;5;28mmin\u001b[39m(\u001b[38;5;28mself\u001b[39m.config(\u001b[33m\"\u001b[39m\u001b[33mnumber-of-download-threads\u001b[39m\u001b[33m\"\u001b[39m), \u001b[38;5;28mlen\u001b[39m(\u001b[38;5;28mself\u001b[39m.requests))\n\u001b[32m    125\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m nthreads < \u001b[32m2\u001b[39m:\n\u001b[32m--> \u001b[39m\u001b[32m126\u001b[39m     \u001b[38;5;28mself\u001b[39m.path = [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_retrieve\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdataset\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mr\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m r \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.requests]\n\u001b[32m    127\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    128\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m SoftThreadPool(nthreads=nthreads) \u001b[38;5;28;01mas\u001b[39;00m pool:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\cds.py:140\u001b[39m, in \u001b[36mCdsRetriever._retrieve\u001b[39m\u001b[34m(self, dataset, request)\u001b[39m\n\u001b[32m    137\u001b[39m     \u001b[38;5;28mself\u001b[39m.source_filename = cds_result.location.split(\u001b[33m\"\u001b[39m\u001b[33m/\u001b[39m\u001b[33m\"\u001b[39m)[-\u001b[32m1\u001b[39m]\n\u001b[32m    138\u001b[39m     cds_result.download(target=target)\n\u001b[32m--> \u001b[39m\u001b[32m140\u001b[39m return_object = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcache_file\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    141\u001b[39m \u001b[43m    \u001b[49m\u001b[43mretrieve\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    142\u001b[39m \u001b[43m    \u001b[49m\u001b[43m(\u001b[49m\u001b[43mdataset\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrequest\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    143\u001b[39m \u001b[43m    \u001b[49m\u001b[43mextension\u001b[49m\u001b[43m=\u001b[49m\u001b[43mEXTENSIONS\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrequest\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mformat\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m.cache\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    144\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    145\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m return_object\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\__init__.py:68\u001b[39m, in \u001b[36mSource.cache_file\u001b[39m\u001b[34m(self, create, args, **kwargs)\u001b[39m\n\u001b[32m     65\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m owner \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m     66\u001b[39m     owner = re.sub(\u001b[33mr\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m(?!^)([A-Z]+)\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33mr\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m-\u001b[39m\u001b[33m\\\u001b[39m\u001b[33m1\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28mself\u001b[39m.\u001b[34m__class__\u001b[39m.\u001b[34m__name__\u001b[39m).lower()\n\u001b[32m---> \u001b[39m\u001b[32m68\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mcache_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mowner\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\core\\caching.py:1061\u001b[39m, in \u001b[36mcache_file\u001b[39m\u001b[34m(owner, create, args, hash_extra, extension, force, replace)\u001b[39m\n\u001b[32m   1059\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m FileLock(lock):\n\u001b[32m   1060\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m os.path.exists(path):  \u001b[38;5;66;03m# Check again, another thread/process may have created the file\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1061\u001b[39m         owner_data = \u001b[43mcreate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m \u001b[49m\u001b[43m+\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m.tmp\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1062\u001b[39m         os.rename(path + \u001b[33m\"\u001b[39m\u001b[33m.tmp\u001b[39m\u001b[33m\"\u001b[39m, path)\n\u001b[32m   1063\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\earthkit\\data\\sources\\cds.py:136\u001b[39m, in \u001b[36mCdsRetriever._retrieve.<locals>.retrieve\u001b[39m\u001b[34m(target, args)\u001b[39m\n\u001b[32m    135\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mretrieve\u001b[39m(target, args):\n\u001b[32m--> \u001b[39m\u001b[32m136\u001b[39m     cds_result = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mclient\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43mretrieve\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    137\u001b[39m     \u001b[38;5;28mself\u001b[39m.source_filename = cds_result.location.split(\u001b[33m\"\u001b[39m\u001b[33m/\u001b[39m\u001b[33m\"\u001b[39m)[-\u001b[32m1\u001b[39m]\n\u001b[32m    138\u001b[39m     cds_result.download(target=target)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\ecmwf\\datastores\\legacy_client.py:167\u001b[39m, in \u001b[36mLegacyClient.retrieve\u001b[39m\u001b[34m(self, name, request, target)\u001b[39m\n\u001b[32m    165\u001b[39m submitted: datastores.Remote | datastores.Results\n\u001b[32m    166\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.wait_until_complete:\n\u001b[32m--> \u001b[39m\u001b[32m167\u001b[39m     submitted = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mclient\u001b[49m\u001b[43m.\u001b[49m\u001b[43msubmit_and_wait_on_results\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    168\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcollection_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    169\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrequest\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrequest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    170\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    171\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    172\u001b[39m     submitted = \u001b[38;5;28mself\u001b[39m.client.submit(\n\u001b[32m    173\u001b[39m         collection_id=name,\n\u001b[32m    174\u001b[39m         request=request,\n\u001b[32m    175\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\ecmwf\\datastores\\client.py:414\u001b[39m, in \u001b[36mClient.submit_and_wait_on_results\u001b[39m\u001b[34m(self, collection_id, request)\u001b[39m\n\u001b[32m    398\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34msubmit_and_wait_on_results\u001b[39m(\n\u001b[32m    399\u001b[39m     \u001b[38;5;28mself\u001b[39m, collection_id: \u001b[38;5;28mstr\u001b[39m, request: \u001b[38;5;28mdict\u001b[39m[\u001b[38;5;28mstr\u001b[39m, Any]\n\u001b[32m    400\u001b[39m ) -> datastores.Results:\n\u001b[32m    401\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Submit a request and wait for the results to be ready.\u001b[39;00m\n\u001b[32m    402\u001b[39m \n\u001b[32m    403\u001b[39m \u001b[33;03m    Parameters\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    412\u001b[39m \u001b[33;03m    datastores.Results\u001b[39;00m\n\u001b[32m    413\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m414\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_retrieve_api\u001b[49m\u001b[43m.\u001b[49m\u001b[43msubmit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcollection_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrequest\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_results\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\ecmwf\\datastores\\processing.py:495\u001b[39m, in \u001b[36mRemote.get_results\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    488\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mget_results\u001b[39m(\u001b[38;5;28mself\u001b[39m) -> Results:\n\u001b[32m    489\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Retrieve results.\u001b[39;00m\n\u001b[32m    490\u001b[39m \n\u001b[32m    491\u001b[39m \u001b[33;03m    Returns\u001b[39;00m\n\u001b[32m    492\u001b[39m \u001b[33;03m    -------\u001b[39;00m\n\u001b[32m    493\u001b[39m \u001b[33;03m    datastores.Results\u001b[39;00m\n\u001b[32m    494\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m495\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_make_results\u001b[49m\u001b[43m(\u001b[49m\u001b[43mwait\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\ecmwf\\datastores\\processing.py:479\u001b[39m, in \u001b[36mRemote._make_results\u001b[39m\u001b[34m(self, wait)\u001b[39m\n\u001b[32m    477\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_make_results\u001b[39m(\u001b[38;5;28mself\u001b[39m, wait: \u001b[38;5;28mbool\u001b[39m) -> Results:\n\u001b[32m    478\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m wait:\n\u001b[32m--> \u001b[39m\u001b[32m479\u001b[39m         \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_wait_on_results\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    480\u001b[39m     response = \u001b[38;5;28mself\u001b[39m._get_api_response(\u001b[33m\"\u001b[39m\u001b[33mget\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m    481\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\karimba\\AppData\\Local\\miniconda3\\envs\\climate-tools-py313\\Lib\\site-packages\\ecmwf\\datastores\\processing.py:459\u001b[39m, in \u001b[36mRemote._wait_on_results\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    457\u001b[39m \u001b[38;5;28;01mwhile\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m.results_ready:\n\u001b[32m    458\u001b[39m     \u001b[38;5;28mself\u001b[39m.debug(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mresults not ready, waiting for \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msleep\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m seconds\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m--> \u001b[39m\u001b[32m459\u001b[39m     \u001b[43mtime\u001b[49m\u001b[43m.\u001b[49m\u001b[43msleep\u001b[49m\u001b[43m(\u001b[49m\u001b[43msleep\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    460\u001b[39m     sleep = \u001b[38;5;28mmin\u001b[39m(sleep * \u001b[32m1.5\u001b[39m, \u001b[38;5;28mself\u001b[39m.sleep_max)\n",
+      "\u001b[31mKeyboardInterrupt\u001b[39m: "
+     ]
     }
    ],
    "source": [
@@ -603,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1252,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1284,7 +1299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1937,7 +1952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2496,7 +2511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2633,7 +2648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2683,7 +2698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2737,7 +2752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2765,7 +2780,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "climate-tools-new",
+   "display_name": "climate-tools-py313",
    "language": "python",
    "name": "python3"
   },
@@ -2779,7 +2794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/workflows/scheduling/schedule-era5-import.md
+++ b/docs/workflows/scheduling/schedule-era5-import.md
@@ -55,7 +55,7 @@ Since we are using [papermill](https://papermill.readthedocs.io/) to run the not
 Papermill can then [read parameters from a yaml file](https://papermill.readthedocs.io/en/latest/usage-execute.html#using-a-parameters-file), and then inject and override those defined in the notebook cell with the `parameters` tag. For this tutorial, we have included an [import-temperature-config.yaml](./example/configs/import-temperature-config.yaml) file where we set the parameters to import temperature data instead of the default precipitation. 
 
 ```bash
-DHIS2_BASE_URL: https://play.im.dhis2.org/stable-2-42-3-1
+DHIS2_BASE_URL: https://climate.im.dhis2.org/climate-tools-42
 DHIS2_USERNAME: admin
 DHIS2_PASSWORD: district
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-498

We now point to a dedicated climate-tools instance at https://climate.im.dhis2.org/climate-tools-42, that users can experiment against and which will reset nightly. 