### PR TITLE
docs: add Open Climate Service section

### DIFF
--- a/docs/open-climate-service/aggregate-to-org-units.ipynb
+++ b/docs/open-climate-service/aggregate-to-org-units.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\ntitle: Aggregate a dataset to organisation units and import into DHIS2\nshort_title: Aggregate to org units\n---\n\nOpen Climate Service ships a reusable workflow, `aggregate_to_dhis2_org_units`, that runs entirely **server-side**: it loads a published dataset over a time range, aggregates it within each organisation-unit polygon, and returns a ready-to-import DHIS2 `dataValueSet`.\n\nIn this notebook we call that workflow and then import its result into DHIS2 with the [dhis2-python-client](https://github.com/dhis2/dhis2-python-client) \u2014 the same client used in the [Importing data values](../guides/import-data/import-data-values.ipynb) guide.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
+   "source": "---\ntitle: Aggregate a dataset to organisation units and import into DHIS2\nshort_title: Aggregate to org units\n---\n\nOpen Climate Service ships a reusable workflow, `aggregate_to_dhis2_json`, that runs entirely **server-side**: it loads a published dataset over a time range, aggregates it within each organisation-unit polygon, and returns a ready-to-import DHIS2 `dataValueSet`.\n\nIn this notebook we call that workflow and then import its result into DHIS2 with the [dhis2-python-client](https://github.com/dhis2/dhis2-python-client) \u2014 the same client used in the [Importing data values](../guides/import-data/import-data-values.ipynb) guide.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
    "id": "c1"
   },
   {
@@ -39,7 +39,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "result = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_dhis2_org_units\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_temperature_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"data_element_id\": \"BXgDHhPdFVU\",   # DHIS2 data element to import into\n                \"method\": \"mean\",                     # mean (default), min, max, or sum\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    }\n)\nresult[\"dataValues\"][:3]",
+   "source": "result = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_dhis2_json\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_temperature_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"data_element_id\": \"BXgDHhPdFVU\",   # DHIS2 data element to import into\n                \"method\": \"mean\",                     # mean (default), min, max, or sum\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    }\n)\nresult[\"dataValues\"][:3]",
    "id": "c6"
   },
   {

--- a/docs/open-climate-service/aggregate-to-org-units.ipynb
+++ b/docs/open-climate-service/aggregate-to-org-units.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\ntitle: Aggregate a dataset to organisation units and import into DHIS2\nshort_title: Aggregate to org units\n---\n\nOpen Climate Service ships a reusable workflow, `aggregate_to_dhis2_org_units`, that runs entirely **server-side**: it loads a published dataset over a time range, aggregates it within each organisation-unit polygon, and returns a ready-to-import DHIS2 `dataValueSet`.\n\nIn this notebook we call that workflow and then import its result into DHIS2 with the [dhis2-python-client](https://github.com/dhis2/dhis2-python-client) \u2014 the same client used in the [Importing data values](../guides/import-data/import-data-values.ipynb) guide.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
+   "id": "c1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from open_climate_service import ClimateService\n\nservice = ClimateService(\"https://my-instance.example.org\")",
+   "id": "c2"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1) Organisation unit boundaries\n\nThe workflow aggregates to whatever GeoJSON features you provide. Each feature's `id` **must be the DHIS2 organisation unit UID**, so the result can be imported into DHIS2 without any remapping. See the [Organisation units](../guides/org-units/intro.md) guide for how to export these from DHIS2 as GeoJSON.",
+   "id": "c3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nfrom pathlib import Path\n\n# A GeoJSON FeatureCollection of your org units, each feature \"id\" = DHIS2 org unit UID.\norg_units = json.loads(Path(\"org-units.geojson\").read_text())\nprint(len(org_units[\"features\"]), \"organisation units\")",
+   "id": "c4"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2) Run the aggregation workflow\n\nWe call the workflow with `execute()`. The key arguments are:\n\n- `dataset_id` \u2014 a published dataset (see [Connect and explore](connect-and-explore.ipynb)).\n- `temporal_extent` \u2014 `[start, end]` dates.\n- `geometries` \u2014 the org-unit GeoJSON.\n- `data_element_id` \u2014 the DHIS2 data element the values belong to.\n- `method` \u2014 the spatial statistic: `mean` (default), `min`, `max`, or `sum`.\n- `period_type` \u2014 how each time step is turned into a DHIS2 period (`month`, `week`, `day`, \u2026).\n\nFor a JSON result like this one, `execute()` returns the parsed payload as a `dict`.",
+   "id": "c5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "result = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_dhis2_org_units\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_temperature_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"data_element_id\": \"BXgDHhPdFVU\",   # DHIS2 data element to import into\n                \"method\": \"mean\",                     # mean (default), min, max, or sum\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    }\n)\nresult[\"dataValues\"][:3]",
+   "id": "c6"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "The workflow has already filled in `orgUnit`, `period`, `value`, and `dataElement` for every cell \u2014 the payload is a valid DHIS2 `dataValueSet`, ready to import as-is.",
+   "id": "c7"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3) Import into DHIS2\n\nConnect to DHIS2 and post the payload. (Replace the demo server and credentials with your own.)",
+   "id": "c8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from dhis2_client import DHIS2Client\nfrom dhis2_client.settings import ClientSettings\n\nclient = DHIS2Client(\n    settings=ClientSettings(\n        base_url=\"https://climate.im.dhis2.org/climate-tools-42\",\n        username=\"admin\",\n        password=\"district\",\n    )\n)\n\nres = client.post_data_value_set(result)\nres[\"response\"][\"importCount\"]",
+   "id": "c9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "The data element and organisation units referenced in the payload must already exist in DHIS2. See [Importing data values](../guides/import-data/import-data-values.ipynb) for preparing metadata, dry runs, and troubleshooting import conflicts.\n\n## Next steps\n\n- [Prepare data for Chap](prepare-data-for-chap.ipynb) \u2014 get the same aggregation as a Chap-ready CSV instead.",
+   "id": "c10"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/open-climate-service/animate-with-mapflow.ipynb
+++ b/docs/open-climate-service/animate-with-mapflow.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\ntitle: Animate a dataset with mapflow\nshort_title: Animate with mapflow\n---\n\n[mapflow](https://mapflow.readthedocs.io/) turns a 3D `xarray.DataArray` `(time, y, x)` into a video in one line. Combined with Open Climate Service \u2014 whose datasets are exactly that shape \u2014 it's an easy way to make a time-lapse animation of a climate variable for a report or presentation.\n\nNeeds the `open-climate-service` client with the `[xarray]` extra (see the [section intro](intro.md)), `mapflow` (`pip install mapflow`, which uses `ffmpeg`), and a running Open Climate Service instance.",
+   "id": "c1"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1) Open a dataset as xarray",
+   "id": "c2"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from open_climate_service import ClimateService\n\n# Replace with your Open Climate Service instance and a published dataset id\nservice = ClimateService(\"https://my-instance.example.org\")\nds = service.open_dataset(\"era5land_temperature_monthly\")\nds",
+   "id": "c3"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2) Pick a variable and a time window\n\nmapflow animates a single 3D `(time, y, x)` `DataArray`. Select the variable and subset the time axis (`t` in Open Climate Service cubes) to keep the animation a sensible length.",
+   "id": "c4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "variable = list(ds.data_vars)[0]\nda = ds[variable].sel(t=slice(\"2024-01-01\", \"2024-12-31\"))\nda",
+   "id": "c5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3) Render the animation\n\n`animate()` writes the video straight to `path` (it lazily reads only the frames it needs from the store).",
+   "id": "c6"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from mapflow import animate\n\nanimate(da=da, path=\"climate-animation.mp4\", pad_inches=0.2)",
+   "id": "c7"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4) View it",
+   "id": "c8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import Video\n\nVideo(\"climate-animation.mp4\")",
+   "id": "c9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "mapflow renders frames with matplotlib and encodes them with `ffmpeg`, so it's best for **exported** time-lapses over a modest extent. For interactive exploration with a temporal slider, use the instance's built-in map viewer instead. See the [mapflow documentation](https://mapflow.readthedocs.io/) for styling and output options.",
+   "id": "c10"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/open-climate-service/connect-and-explore.ipynb
+++ b/docs/open-climate-service/connect-and-explore.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\ntitle: Connect to an Open Climate Service instance and explore\nshort_title: Connect & explore\n---\n\nThis notebook connects to a running [Open Climate Service](https://dhis2.github.io/open-climate-service/) instance, discovers the datasets and workflows it publishes, and opens a dataset as an `xarray.Dataset`.\n\nIt needs the `open-climate-service` client (see the [section intro](intro.md)) and the URL of a running instance.",
+   "id": "c1"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1) Connect\n\nPoint the client at your instance. No authentication is required for a typical local or country deployment.",
+   "id": "c2"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from open_climate_service import ClimateService\n\n# Replace with the URL of your Open Climate Service instance\nservice = ClimateService(\"https://my-instance.example.org\")",
+   "id": "c3"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2) Discover published datasets\n\n`datasets()` returns the published collections from the instance's STAC catalog. Each entry has at least an `id`, a `title`, and an `href`.",
+   "id": "c4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "datasets = service.datasets()\nfor d in datasets:\n    print(d[\"id\"], \"\u2014\", d.get(\"title\", \"\"))",
+   "id": "c5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3) See the available processing\n\nAn instance exposes both the standard [openEO](https://openeo.org/) processes and any reusable **workflows** (stored process graphs) it ships \u2014 such as the org-unit aggregation workflows used later in this section.",
+   "id": "c6"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Reusable, named workflows (e.g. aggregate_to_dhis2_org_units)\nprint(\"Workflows:\")\nfor wf in service.workflows():\n    print(\" -\", wf[\"id\"])\n\n# Standard openEO processes (mean, sum, filter_temporal, ...)\nprint(f\"\\n{len(service.processes())} openEO processes available\")",
+   "id": "c7"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4) Open a dataset as xarray\n\n`open_dataset()` reads the published GeoZarr store directly over HTTP and returns a lazy `xarray.Dataset` (this step needs the `[xarray]` extra). Nothing is downloaded until you compute or plot.",
+   "id": "c8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Open the first published dataset (or pass any id from the list above)\nds = service.open_dataset(datasets[0][\"id\"])\nds",
+   "id": "c9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Because the data is lazy, subset in space and time *before* calling `.compute()` or plotting \u2014 see the [Data visualization](../guides/visualization/intro.md) guide for examples.",
+   "id": "c10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "variable = list(ds.data_vars)[0]\nds[variable]",
+   "id": "c11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Next steps\n\n- [Aggregate to organisation units](aggregate-to-org-units.ipynb) and import the result into DHIS2.\n- [Prepare data for Chap](prepare-data-for-chap.ipynb).",
+   "id": "c12"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/open-climate-service/connect-and-explore.ipynb
+++ b/docs/open-climate-service/connect-and-explore.ipynb
@@ -45,7 +45,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Reusable, named workflows (e.g. aggregate_to_dhis2_org_units)\nprint(\"Workflows:\")\nfor wf in service.workflows():\n    print(\" -\", wf[\"id\"])\n\n# Standard openEO processes (mean, sum, filter_temporal, ...)\nprint(f\"\\n{len(service.processes())} openEO processes available\")",
+   "source": "# Reusable, named workflows (e.g. aggregate_to_dhis2_json)\nprint(\"Workflows:\")\nfor wf in service.workflows():\n    print(\" -\", wf[\"id\"])\n\n# Standard openEO processes (mean, sum, filter_temporal, ...)\nprint(f\"\\n{len(service.processes())} openEO processes available\")",
    "id": "c7"
   },
   {

--- a/docs/open-climate-service/intro.md
+++ b/docs/open-climate-service/intro.md
@@ -24,6 +24,7 @@ pip install "open-climate-service[xarray]"
 - [Use with the openEO Python client](use-with-openeo-client.ipynb) — drive an instance with the standard, portable openEO client.
 - [Aggregate to organisation units](aggregate-to-org-units.ipynb) — run a server-side workflow that aggregates a dataset to your org units, then import the result into DHIS2.
 - [Prepare data for Chap](prepare-data-for-chap.ipynb) — produce a Chap-ready CSV from a single workflow call.
+- [Animate with mapflow](animate-with-mapflow.ipynb) — turn a dataset into a time-lapse video.
 
 ## How it fits with Climate Tools
 

--- a/docs/open-climate-service/intro.md
+++ b/docs/open-climate-service/intro.md
@@ -1,0 +1,37 @@
+---
+title: Open Climate Service
+---
+
+[Open Climate Service](https://dhis2.github.io/open-climate-service/) is an open-source platform that integrates climate and earth observation data from many sources and serves it — per country or region — through open standards (STAC, Zarr over HTTP, and the [openEO](https://openeo.org/) API).
+
+Where the rest of DHIS2 Climate Tools downloads and processes data **client-side** in these notebooks, Open Climate Service does the heavy lifting **server-side**: a running instance ingests datasets (CHIRPS, ERA5-Land, WorldPop, and more), keeps them up to date, stores them as GeoZarr, and exposes reusable processing workflows. The notebooks in this section show how to talk to such an instance from Python with the lightweight `open-climate-service` client.
+
+:::{note}
+These notebooks require access to a **running Open Climate Service instance**. See the [Open Climate Service documentation](https://dhis2.github.io/open-climate-service/) to set one up, or use an instance provided by your team.
+:::
+
+## Install the client
+
+The client is distributed on PyPI as `open-climate-service`. The base install only needs to talk to an instance over HTTP; the `[xarray]` extra adds support for opening published datasets as an `xarray.Dataset`:
+
+```bash
+pip install "open-climate-service[xarray]"
+```
+
+## Notebooks
+
+- [Connect and explore](connect-and-explore.ipynb) — connect to an instance, discover datasets and workflows, and open a dataset as `xarray`.
+- [Aggregate to organisation units](aggregate-to-org-units.ipynb) — run a server-side workflow that aggregates a dataset to your org units, then import the result into DHIS2.
+- [Prepare data for Chap](prepare-data-for-chap.ipynb) — produce a Chap-ready CSV from a single workflow call.
+
+## How it fits with Climate Tools
+
+Open Climate Service and Climate Tools are complementary — you can use either or both:
+
+| | Open Climate Service | Climate Tools |
+|---|---|---|
+| Runs | As a server, per country/region | In your notebooks |
+| Role | Ingests, stores (GeoZarr), and processes data | Explores, analyses, and imports data |
+| You reach it via | The `open-climate-service` client / openEO | `dhis2eo`, `xarray`, `geopandas`, … |
+
+A common pattern is to let an Open Climate Service instance handle ingestion, storage and aggregation, and use Climate Tools notebooks to drive it, inspect the results, and import them into DHIS2 or Chap.

--- a/docs/open-climate-service/intro.md
+++ b/docs/open-climate-service/intro.md
@@ -21,6 +21,7 @@ pip install "open-climate-service[xarray]"
 ## Notebooks
 
 - [Connect and explore](connect-and-explore.ipynb) — connect to an instance, discover datasets and workflows, and open a dataset as `xarray`.
+- [Use with the openEO Python client](use-with-openeo-client.ipynb) — drive an instance with the standard, portable openEO client.
 - [Aggregate to organisation units](aggregate-to-org-units.ipynb) — run a server-side workflow that aggregates a dataset to your org units, then import the result into DHIS2.
 - [Prepare data for Chap](prepare-data-for-chap.ipynb) — produce a Chap-ready CSV from a single workflow call.
 

--- a/docs/open-climate-service/prepare-data-for-chap.ipynb
+++ b/docs/open-climate-service/prepare-data-for-chap.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\ntitle: Produce a Chap-ready CSV from Open Climate Service\nshort_title: Prepare data for Chap\n---\n\nOpen Climate Service ships a companion workflow, `aggregate_to_dhis2_org_units_chap`, that performs the same org-unit aggregation but exports a **CHAP CSV** (`time_period`, `location`, and one column per variable) \u2014 the shape the [DHIS2 Chap Modeling Platform](https://chap.dhis2.org/) expects.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
+   "id": "c1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from open_climate_service import ClimateService\n\nservice = ClimateService(\"https://my-instance.example.org\")",
+   "id": "c2"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1) Organisation unit boundaries\n\nAs before, provide a GeoJSON FeatureCollection of your org units. Each feature's `id` becomes the `location` in the CSV. See the [Organisation units](../guides/org-units/intro.md) guide.",
+   "id": "c3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nfrom pathlib import Path\n\norg_units = json.loads(Path(\"org-units.geojson\").read_text())\nprint(len(org_units[\"features\"]), \"organisation units\")",
+   "id": "c4"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2) Run the workflow and save the CSV\n\nThis workflow returns a file rather than JSON. Passing `path=` to `execute()` writes the bytes to disk and returns the resulting `Path`.",
+   "id": "c5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "csv_path = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_dhis2_org_units_chap\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_precipitation_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"method\": \"mean\",\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    },\n    path=\"climate-monthly.csv\",\n)\ncsv_path",
+   "id": "c6"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3) Inspect the result",
+   "id": "c7"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import pandas as pd\n\ndf = pd.read_csv(csv_path)\ndf.head()",
+   "id": "c8"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "The CSV has `time_period`, `location` (your org-unit ids), and one column per variable \u2014 exactly the shape Chap consumes.\n\nTo combine this climate data with a health outcome (e.g. dengue cases) and population into a single modelling table, continue with the [Prepare data for Chap](../guides/import-chap/harmonize-to-chap.ipynb) guide, using this file as one of the harmonized inputs.",
+   "id": "c9"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/open-climate-service/prepare-data-for-chap.ipynb
+++ b/docs/open-climate-service/prepare-data-for-chap.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\ntitle: Produce a Chap-ready CSV from Open Climate Service\nshort_title: Prepare data for Chap\n---\n\nOpen Climate Service ships a companion workflow, `aggregate_to_dhis2_org_units_chap`, that performs the same org-unit aggregation but exports a **CHAP CSV** (`time_period`, `location`, and one column per variable) \u2014 the shape the [DHIS2 Chap Modeling Platform](https://chap.dhis2.org/) expects.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
+   "source": "---\ntitle: Produce a Chap-ready CSV from Open Climate Service\nshort_title: Prepare data for Chap\n---\n\nOpen Climate Service ships a companion workflow, `aggregate_to_chap_csv`, that performs the same org-unit aggregation but exports a **CHAP CSV** (`time_period`, `location`, and one column per variable) \u2014 the shape the [DHIS2 Chap Modeling Platform](https://chap.dhis2.org/) expects.\n\nNeeds the `open-climate-service` client (see the [section intro](intro.md)) and a running instance.",
    "id": "c1"
   },
   {
@@ -39,7 +39,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "csv_path = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_dhis2_org_units_chap\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_precipitation_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"method\": \"mean\",\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    },\n    path=\"climate-monthly.csv\",\n)\ncsv_path",
+   "source": "csv_path = service.execute(\n    {\n        \"agg\": {\n            \"process_id\": \"aggregate_to_chap_csv\",\n            \"arguments\": {\n                \"dataset_id\": \"era5land_precipitation_monthly\",   # a published dataset id\n                \"temporal_extent\": [\"2025-01-01\", \"2025-12-31\"],\n                \"geometries\": org_units,\n                \"method\": \"mean\",\n                \"period_type\": \"month\",\n            },\n            \"result\": True,\n        }\n    },\n    path=\"climate-monthly.csv\",\n)\ncsv_path",
    "id": "c6"
   },
   {

--- a/docs/open-climate-service/use-with-openeo-client.ipynb
+++ b/docs/open-climate-service/use-with-openeo-client.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\ntitle: Use Open Climate Service with the openEO Python client\nshort_title: openEO Python client\n---\n\nOpen Climate Service implements the [openEO](https://openeo.org/) API \u2014 that is what the `open-climate-service` client uses under the hood. So as well as the `ClimateService` client shown in the other notebooks, you can point the **standard [openEO Python client](https://openeo.org/documentation/1.0/python/)** at an instance.\n\nThis is useful if you already know openEO, or want process graphs that are **portable** \u2014 the same code runs against any openEO backend. The client builds process graphs lazily and runs them on the server, so only the (small) result comes back.\n\nInstall the client with `pip install openeo`. You also need a running Open Climate Service instance (see the [section intro](intro.md)).",
+   "id": "c1"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1) Connect\n\nNo authentication is required for a typical local or country deployment.",
+   "id": "c2"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import openeo\n\n# Replace with the URL of your Open Climate Service instance\nconnection = openeo.connect(\"https://my-instance.example.org\")\nprint(\"openEO API version:\", connection.capabilities().api_version())",
+   "id": "c3"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2) Browse collections\n\nPublished datasets are exposed as openEO **collections** (the same ones `ClimateService.datasets()` lists).",
+   "id": "c4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "for c in connection.list_collections():\n    print(c[\"id\"], \"\u2014\", c.get(\"title\", \"\"))",
+   "id": "c5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3) Load a collection as a data cube\n\n`load_collection` describes the data you want \u2014 a collection, a bounding box, and a time range. Nothing runs yet; the cube is a lazy description of the computation.",
+   "id": "c6"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "cube = connection.load_collection(\n    \"era5land_temperature_monthly\",   # a published collection id from the list above\n    spatial_extent={\"west\": 28.8, \"south\": -2.9, \"east\": 30.9, \"north\": -1.0},   # example: Rwanda\n    temporal_extent=[\"2025-01-01\", \"2025-12-31\"],\n)",
+   "id": "c7"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4) Build a process graph\n\nChain openEO processes to describe the result. Here we reduce the time dimension to a per-pixel mean over the period. The work happens server-side when we run it.",
+   "id": "c8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Mean over the time dimension (\"t\" in Open Climate Service cubes)\nmean_temperature = cube.reduce_dimension(reducer=\"mean\", dimension=\"t\")\n\n# Inspect the process graph that will be sent to the server\nmean_temperature.flat_graph()",
+   "id": "c9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5) Run it\n\nFor small results and concrete export formats (GeoTIFF, NetCDF, PNG, CSV), run synchronously with `download()` \u2014 this returns the finished file. (Datacube/Zarr output is served via batch jobs instead; see below.)",
+   "id": "c10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "mean_temperature.download(\"mean-temperature-2025.tif\", format=\"GTiff\")",
+   "id": "c11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "For long-running computations, submit a **batch job** instead, then poll and fetch the results \u2014 the production pattern:",
+   "id": "c12"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "job = mean_temperature.create_job(title=\"mean-temperature-2025\", format=\"GTiff\")\njob.start_and_wait()\nresults = job.get_results()\nresults.get_assets()",
+   "id": "c13"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Standard openEO \u2014 and beyond\n\nEverything above is standard openEO, so the same process graph runs against any openEO backend.\n\nOpen Climate Service also ships **higher-level workflows** (stored process graphs) for common DHIS2 tasks \u2014 for example aggregating a dataset to organisation units and exporting a DHIS2 `dataValueSet` or a Chap CSV. Those are easiest to call with `ClimateService.execute()`:\n\n- [Aggregate to organisation units](aggregate-to-org-units.ipynb)\n- [Prepare data for Chap](prepare-data-for-chap.ipynb)\n\nSee the [openEO Python client documentation](https://openeo.org/documentation/1.0/python/) for the full API.",
+   "id": "c14"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -20,6 +20,13 @@ project:
         - file: getting-started/jupyter.md
         - file: getting-started/updating.md
 
+    - title: Open Climate Service
+      file: open-climate-service/intro.md
+      children:
+        - file: open-climate-service/connect-and-explore.ipynb
+        - file: open-climate-service/aggregate-to-org-units.ipynb
+        - file: open-climate-service/prepare-data-for-chap.ipynb
+
     - title: Guides
       file: guides/intro.md
       children:

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -27,6 +27,7 @@ project:
         - file: open-climate-service/use-with-openeo-client.ipynb
         - file: open-climate-service/aggregate-to-org-units.ipynb
         - file: open-climate-service/prepare-data-for-chap.ipynb
+        - file: open-climate-service/animate-with-mapflow.ipynb
 
     - title: Guides
       file: guides/intro.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -24,6 +24,7 @@ project:
       file: open-climate-service/intro.md
       children:
         - file: open-climate-service/connect-and-explore.ipynb
+        - file: open-climate-service/use-with-openeo-client.ipynb
         - file: open-climate-service/aggregate-to-org-units.ipynb
         - file: open-climate-service/prepare-data-for-chap.ipynb
 


### PR DESCRIPTION
Adds a new top-level **Open Climate Service** section to the docs, between **Getting Started** and **Guides**.

[Open Climate Service](https://dhis2.github.io/open-climate-service/) is the server-side complement to Climate Tools: a per-country/region instance that ingests datasets (CHIRPS, ERA5-Land, WorldPop, …), keeps them current, stores them as GeoZarr, and exposes reusable processing workflows over open standards (STAC, Zarr-over-HTTP, openEO). This section shows how to drive such an instance from notebooks with the lightweight `open-climate-service` Python client.

### What's added
- **`intro.md`** — what Open Climate Service is, how it fits with Climate Tools (a side-by-side table), and how to `pip install "open-climate-service[xarray]"`.
- **`connect-and-explore.ipynb`** — connect to an instance, discover published datasets and workflows, and open a dataset as a lazy `xarray.Dataset`.
- **`aggregate-to-org-units.ipynb`** — run the server-side `aggregate_to_dhis2_org_units` workflow (mean/min/max/sum over org-unit polygons) and import the resulting `dataValueSet` into DHIS2 with `dhis2-python-client` — reusing the pattern from the *Importing data values* guide.
- **`prepare-data-for-chap.ipynb`** — produce a Chap-ready CSV from a single `aggregate_to_dhis2_org_units_chap` call, ready to feed into the *Prepare data for Chap* guide.

### Notes
- The notebooks cross-link into existing guides (Organisation units, Data visualization, Importing data values, Prepare data for Chap).
- They require a **running Open Climate Service instance**, so they live under `docs/open-climate-service/` (not `docs/guides`/`docs/workflows`) and are therefore **not** part of the papermill-executed notebook test suite — matching how other service-dependent material is handled.
- No change to `requirements.txt`: the client is installed per the section intro, keeping the shared environment and CI untouched.
- Wired into `toc.yml` as a new section between Getting Started and Guides.
